### PR TITLE
Fix snippet source path when target dir is "."

### DIFF
--- a/src/MarkdownSnippets/Processing/GitHubSnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/GitHubSnippetMarkdownHandling.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace MarkdownSnippets
 {
@@ -36,7 +37,10 @@ namespace MarkdownSnippets
 
             if (snippet.Path != null)
             {
-                var path = snippet.Path.Replace(@"\", "/").ReplaceCaseless(repositoryRoot,"");
+                var path = Regex.Replace(snippet.Path.Replace(@"\", "/"),
+                                         "^" + Regex.Escape(repositoryRoot),
+                                         string.Empty,
+                                         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                 writer.WriteLine($"<sup>[snippet source]({path}#L{snippet.StartLine}-L{snippet.EndLine})</sup>");
             }
         }


### PR DESCRIPTION
This PR fixes issue #7.

The fix makes sure that the repository root is cleared out from only if the snippet path starts with it, which is what I think was originally intended. The bug is that when `repositoryRoot` is `"."`, `ReplaceCaseless` will remove all dots.

There may be better ways than `Regex.Replace` but those can always be worked on after. For now, I believe this addresses the issue.