### PR TITLE
Remove redundant file deletion

### DIFF
--- a/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
+++ b/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
@@ -65,10 +65,6 @@ namespace MarkdownSnippets
             log($"Processing {sourceFile}");
             // remove ".md" from ".source.md" then change ".source" to ".md"
             var target = Path.ChangeExtension(Path.ChangeExtension(sourceFile, null), ".md");
-            if (File.Exists(target))
-            {
-                File.Delete(target);
-            }
             using (var reader = File.OpenText(sourceFile))
             using (var writer = File.CreateText(target))
             {


### PR DESCRIPTION
The file deletion this PR suggests to remove is entirely redundant because `File.CreateText` later will either create the file or open the existing one with all content reset to empty. Removing the redundant deletion has the following benefits (in order of descending importance as I see it):

- Fewer and superfluous change notifications for file watchers
- The creation date/time of the file that existed is maintained and just the last write time updated
- Fewer disk I/O (existence check + deletion + re-creation) or less (including code) is more
- Atomic
