### PR TITLE
Don't potentially mix EOL sequences in output documents

### DIFF
--- a/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
+++ b/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
@@ -68,12 +68,12 @@ namespace MarkdownSnippets
             using (var reader = File.OpenText(sourceFile))
             using (var writer = File.CreateText(target))
             {
-                writer.WriteLine($@"<!--
-This file was generate by MarkdownSnippets.
-Source File: {sourceFile.ReplaceCaseless(targetDirectory,"")}
-To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).
--->
-");
+                writer.WriteLine(@"<!--");
+                writer.WriteLine(@"This file was generate by MarkdownSnippets.");
+                writer.WriteLine($@"Source File: {sourceFile.ReplaceCaseless(targetDirectory,"")}");
+                writer.WriteLine(@"To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).");
+                writer.WriteLine(@"-->");
+
                 var processResult = markdownProcessor.Apply(reader, writer);
                 var missing = processResult.MissingSnippets;
                 if (missing.Any())

--- a/src/MarkdownSnippets/Processing/GitHubSnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/GitHubSnippetMarkdownHandling.cs
@@ -30,10 +30,9 @@ namespace MarkdownSnippets
 
         void WriteSnippet(TextWriter writer, Snippet snippet)
         {
-            var format = $@"```{snippet.Language}
-{snippet.Value}
-```";
-            writer.WriteLine(format);
+            writer.WriteLine($"```{snippet.Language}");
+            writer.WriteLine(snippet.Value);
+            writer.WriteLine("```");
 
             if (snippet.Path != null)
             {

--- a/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
@@ -21,10 +21,9 @@ namespace MarkdownSnippets
 
         static void WriteSnippet(TextWriter writer, Snippet snippet)
         {
-            var format = $@"```{snippet.Language}
-{snippet.Value}
-```";
-            writer.WriteLine(format);
+            writer.WriteLine($@"```{snippet.Language}");
+            writer.WriteLine(snippet.Value);
+            writer.WriteLine(@"```");
         }
     }
 }


### PR DESCRIPTION
This PR fixes the trouble with C# verbatim strings that new-line (EOL) endings get hard-coded into the compiler binary based on the platform where it was compiled. The resulting documents, once again depending on the platform, could then potentially end up with mixed cases of EOL sequences. It seems that most instances in the code using verbatim strings to insert text into the resulting Markdown could just do with `WriteLine` of a `TextWriter` instance, which is usually initialised with the new-line sequence of the host platform. The outcome is dull, having the least element of surprise, which unfortunately/apparently is a Good Thing&trade;. 😜 