### PR TITLE
Normalize directory separator in source file stamp

### DIFF
--- a/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
+++ b/src/MarkdownSnippets/Processing/GitHubMarkdownProcessor.cs
@@ -70,7 +70,8 @@ namespace MarkdownSnippets
             {
                 writer.WriteLine(@"<!--");
                 writer.WriteLine(@"This file was generate by MarkdownSnippets.");
-                writer.WriteLine($@"Source File: {sourceFile.ReplaceCaseless(targetDirectory,"")}");
+                writer.WriteLine($@"Source File: {sourceFile.ReplaceCaseless(targetDirectory, "")
+                                                            .Replace('\\', '/')}");
                 writer.WriteLine(@"To change this file edit the source file and then re-run the generation using either the dotnet global tool (https://github.com/SimonCropp/MarkdownSnippets#githubmarkdownsnippets) or using the api (https://github.com/SimonCropp/MarkdownSnippets#running-as-a-unit-test).");
                 writer.WriteLine(@"-->");
 


### PR DESCRIPTION
I have Markdown documents generated on Windows from their `*.source.md` counterparts. Those same documents on a *nix system appear as a change in the SCM due to different directory separators:

```diff
-Source File: \docs.src\index.source.md
+Source File: /docs.src/index.source.md
```

This PR proposes to normalize directory separators on forward-slash (`/`), which works for Windows and *nix systems.

