### PR TITLE
Add .NET Core App 2.1 as an additional target

### DIFF
--- a/src/MarkdownSnippets.Tool/MarkdownSnippets.Tool.csproj
+++ b/src/MarkdownSnippets.Tool/MarkdownSnippets.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <ToolCommandName>mdsnippets</ToolCommandName>
     <AssemblyName>mdsnippets</AssemblyName>
     <PackageId>MarkdownSnippets.Tool</PackageId>


### PR DESCRIPTION
Because it can be done super easily and it seems wasteful to ask users to have .NET Core SDK 2.2 installed just for this tool if they don't have it. For example, doing this:

    docker run --rm -it microsoft/dotnet:2.1-sdk dotnet tool install -g MarkdownSnippets.Tool

gives the error:

```
error NU1202: Package MarkdownSnippets.Tool 9.1.0 is not compatible with netcoreapp2.1 (.NETCoreApp,Version=v2.1) / any. Package MarkdownSnippets.Tool 9.1.0 supports: netcoreapp2.2 (.NETCoreApp,Version=v2.2) / any
The tool package could not be restored.
Tool 'markdownsnippets.tool' failed to install. This failure may have been caused by:

* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET Core tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.
```
