### PR TITLE
split urls by space

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,7 +349,7 @@ UrlPrefix allows a string to be defined that will prefix all snippet links. This
 
 ## UrlsAsSnippets
 
-Urls to files to be included as snippets. Colon `:` separated for multiple values.
+Urls to files to be included as snippets. Space ` ` separated for multiple values.
 
 ```ps
 mdsnippets --urls-as-snippets "https://github.com/SimonCropp/MarkdownSnippets/snippet.cs"

--- a/readme.source.md
+++ b/readme.source.md
@@ -242,7 +242,7 @@ UrlPrefix allows a string to be defined that will prefix all snippet links. This
 
 ## UrlsAsSnippets
 
-Urls to files to be included as snippets. Colon `:` separated for multiple values.
+Urls to files to be included as snippets. Space ` ` separated for multiple values.
 
 ```ps
 mdsnippets --urls-as-snippets "https://github.com/SimonCropp/MarkdownSnippets/snippet.cs"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591</NoWarn>
-    <Version>17.7.2</Version>
+    <Version>18.0.0</Version>
     <PackageTags>Markdown, Snippets, mdsnippets, documentation, MarkdownSnippets</PackageTags>
     <Description>Extracts snippets from code files and merges them into markdown documents.</Description>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <NoWarn>CS1591</NoWarn>
-    <Version>18.0.0</Version>
+    <NoWarn>CS1591</NoWarn>>
+    <Version>17.7.2</Version>
     <PackageTags>Markdown, Snippets, mdsnippets, documentation, MarkdownSnippets</PackageTags>
     <Description>Extracts snippets from code files and merges them into markdown documents.</Description>
   </PropertyGroup>

--- a/src/MarkdownSnippets.Tool/Options.cs
+++ b/src/MarkdownSnippets.Tool/Options.cs
@@ -22,9 +22,9 @@ public class Options
     public IList<string> TocExcludes { get; set; } = null!;
 
     [Option('u', "urls-as-snippets",
-        Separator = ':',
+        Separator = ' ',
         Required = false,
-        HelpText = "Urls to files to be included as snippets. Optional. Colon ':' separated for multiple values.")]
+        HelpText = "Urls to files to be included as snippets. Optional. Space ' ' separated for multiple values.")]
     public IList<string> UrlsAsSnippets { get; set; } = null!;
 
     [Option('r', "readonly",

--- a/src/Tests/Console/CommandRunnerTests.cs
+++ b/src/Tests/Console/CommandRunnerTests.cs
@@ -143,14 +143,14 @@ public class CommandRunnerTests :
     [Fact]
     public void UrlsAsSnippetsMultiple()
     {
-        CommandRunner.RunCommand(Capture, "-u", "url1:url2");
+        CommandRunner.RunCommand(Capture, "-u", "url1 url2");
         VerifyResult();
     }
 
     [Fact]
     public void UrlsAsSnippetsDuplicates()
     {
-        Assert.Throws<CommandLineException>(() => CommandRunner.RunCommand(Capture, "-u", "url:url"));
+        Assert.Throws<CommandLineException>(() => CommandRunner.RunCommand(Capture, "-u", "url url"));
     }
 
     [Fact]


### PR DESCRIPTION
[UrlsAsSnippets](https://github.com/SimonCropp/MarkdownSnippets#urlsassnippets) were previously split by colon `:`. This was problematic since colon is a common character to include in a url. 

Multiple urls will now be split on space