### PR TITLE
Add failing test for toc in file with no headings

### DIFF
--- a/src/Tests/MarkdownProcessor/MarkdownProcessorTests.TocRetainedIfNoHeadingsInFile.verified.txt
+++ b/src/Tests/MarkdownProcessor/MarkdownProcessorTests.TocRetainedIfNoHeadingsInFile.verified.txt
@@ -1,0 +1,13 @@
+{
+  content: '
+# Title
+
+<!-- toc -->
+<!-- endToc -->
+
+This document has no headings.
+
+An empty toc section should be generated, in case
+any headings are added in future.
+'
+}

--- a/src/Tests/MarkdownProcessor/MarkdownProcessorTests.cs
+++ b/src/Tests/MarkdownProcessor/MarkdownProcessorTests.cs
@@ -243,6 +243,24 @@ Text2
     }
 
     [Fact]
+    public Task TocRetainedIfNoHeadingsInFile()
+    {
+        var content = @"
+# Title
+
+toc
+
+This document has no headings.
+
+An empty toc section should be generated, in case
+any headings are added in future.
+";
+        return SnippetVerifier.Verify(
+            DocumentConvention.SourceTransform,
+            content);
+    }
+
+    [Fact]
     public Task Missing_endToc()
     {
         var content = @"


### PR DESCRIPTION
From https://twitter.com/ClareMacraeUK/status/1300386326852915200

> A tiny comment - I added a toc line to a file with no headings, so if headings are ever added the toc will appear... mdsnippets deleted the toc line, to the change got lost...

This adds a test case for that scenario.

In the verified file, I opted for leaving this text in place if there are no headings present:

```markdown
<!-- toc -->
<!-- endToc -->
```