### PR TITLE
display filename and linenumber when end tag is missing

### DIFF
--- a/src/MarkdownSnippets.Tool/Program.cs
+++ b/src/MarkdownSnippets.Tool/Program.cs
@@ -20,11 +20,17 @@ catch (ConfigurationException exception)
     Console.WriteLine($"Failed: {exception.Message}");
     Environment.Exit(1);
 }
+catch (MarkdownProcessingException exception)
+{
+    Console.WriteLine($"Failed: {exception.Message}, File:'{exception.File}', Line:{exception.LineNumber}.");
+    Environment.Exit(1);
+}
 catch (SnippetException exception)
 {
     Console.WriteLine($"Failed: {exception.Message}");
     Environment.Exit(1);
 }
+
 finally
 {
     Console.WriteLine($"Finished {stopwatch.ElapsedMilliseconds}ms");


### PR DESCRIPTION
When there is a missing end snippet tag in a markdown file, the error message does not show you which file contains the error. 

Below is a sample output showing the current behavior.

```log
C:\src\git-alan-public\konsole>mdsnippets
Config:
    TargetDirectory: C:\src\git-alan-public\konsole
    UrlPrefix:
    LinkFormat: GitHub
    Convention: InPlaceOverwrite
    TocLevel: 2
    ValidateContent: False
    HashSnippetAnchors: False
    TreatMissingAsWarning: False
    FileConfigPath: C:\src\git-alan-public\konsole\mdsnippets.json (exists:True)
Found 200 files for snippets
Added 14 snippets (61ms)
Failed: Expected to find `<!-- endSnippet -->`.
```
This pull request is to display more helpful error message. With the change the last line in the output becomes

```log
Failed: Expected to find `<!-- endSnippet -->`., File:'/readme-iconsole.md', Line:30.
```