### PR TITLE
Option to omit only the source link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -277,10 +277,11 @@ public enum LinkFormat
     GitHub,
     Tfs,
     Bitbucket,
-    GitLab
+    GitLab,
+    None
 }
 ```
-<sup><a href='/src/MarkdownSnippets/Processing/LinkFormat.cs#L1-L9' title='Snippet source file'>snippet source</a> | <a href='#snippet-LinkFormat.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/MarkdownSnippets/Processing/LinkFormat.cs#L1-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-LinkFormat.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -262,6 +262,8 @@ mdsnippets --omit-snippet-links true
 
 snippet: LinkFormat.cs
 
+Link format `None` will omit the source link but still keep the snippet anchor.
+
 
 #### How links are constructed
 

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,8 @@
         "Tfs",
         "GitHub",
         "Bitbucket",
-        "GitLab"
+        "GitLab",
+        "None"
       ],
       "pattern": "^.*$"
     },

--- a/src/MarkdownSnippets/Processing/LinkFormat.cs
+++ b/src/MarkdownSnippets/Processing/LinkFormat.cs
@@ -5,5 +5,6 @@ public enum LinkFormat
     GitHub,
     Tfs,
     Bitbucket,
-    GitLab
+    GitLab,
+    None
 }

--- a/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
@@ -24,7 +24,7 @@ public class SnippetMarkdownHandling
 
         if (hashSnippetAnchors)
         {
-            getAnchorId  = ComputeId;
+            getAnchorId = ComputeId;
         }
         else
         {
@@ -68,7 +68,7 @@ public class SnippetMarkdownHandling
             return id;
         }
 
-        return  $"{id}-{index}";
+        return $"{id}-{index}";
     }
 
     static string ComputeId(Snippet snippet)
@@ -81,7 +81,7 @@ public class SnippetMarkdownHandling
     string GetSupText(Snippet snippet, string anchor)
     {
         var linkForAnchor = $"<a href='#{anchor}' title='Start of snippet'>anchor</a>";
-        if (snippet.Path == null)
+        if (snippet.Path == null || linkFormat == LinkFormat.None)
         {
             return linkForAnchor;
         }

--- a/src/Tests/SnippetMarkdownHandlingTests.AppendOmitSourceLink.verified.txt
+++ b/src/Tests/SnippetMarkdownHandlingTests.AppendOmitSourceLink.verified.txt
@@ -1,0 +1,5 @@
+﻿<a id='snippet-thekey'></a>
+```thelanguage
+theValue
+```
+<sup><a href='#snippet-thekey' title='Start of snippet'>anchor</a></sup>

--- a/src/Tests/SnippetMarkdownHandlingTests.cs
+++ b/src/Tests/SnippetMarkdownHandlingTests.cs
@@ -1,4 +1,4 @@
-﻿using MarkdownSnippets;
+using MarkdownSnippets;
 
 [UsesVerify]
 public class SnippetMarkdownHandlingTests
@@ -9,6 +9,20 @@ public class SnippetMarkdownHandlingTests
         var builder = new StringBuilder();
         var snippets = Snippets();
         var markdownHandling = new SnippetMarkdownHandling("c:/dir/", LinkFormat.GitHub, false, false);
+        using (var writer = new StringWriter(builder))
+        {
+            markdownHandling.Append("key1", snippets, writer.WriteLine);
+        }
+
+        return Verify(builder.ToString());
+    }
+
+    [Fact]
+    public Task AppendOmitSourceLink()
+    {
+        var builder = new StringBuilder();
+        var snippets = Snippets();
+        var markdownHandling = new SnippetMarkdownHandling("c:/dir/", LinkFormat.None, false, false);
         using (var writer = new StringWriter(builder))
         {
             markdownHandling.Append("key1", snippets, writer.WriteLine);


### PR DESCRIPTION
This is a feature request to omit the source link but keep the snippet anchor. For some reason `Tfs` don't work for Azure DevOps (The format on DevOps is `&line=26&lineEnd=30&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents` but `Tfs` gets escaped to `%26line%3D3%26lineEnd%3D24`) and since I don't really know how to fix that bug at least it would be nice to hide it :)

I tried to update `readme.md` but I got this exception:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/6783879/169806834-349991de-1cdc-4591-bb7d-09c807563f28.png">

Might be because I managed to checkout a lot of files with the wrong line ending (at least that's why I guess a lot of files are marked as modified without me touching anything)...

If you approve of this PR, could you try to update `readme.md` for me?