### PR TITLE
Update readme to point to .net 8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ A [dotnet tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools)
 
 **See [Milestones](../../milestones?state=closed) for release notes.**
 
-**[.net 6](https://dotnet.microsoft.com/download/dotnet/6.0) or higher is required to run this tool.**
+**[.net 8](https://dotnet.microsoft.com/download/dotnet/8.0) or higher is required to run this tool.**
 
 ## Value Proposition
 


### PR DESCRIPTION
Hi Simon,

I tried installing mdsnippets against .net 7 today and got an error - .net 8 worked.

So here is a suggestion to update the readme, if indeed 8 is the right answer...