### PR TITLE
Ensure that all paths starting with a period are ignored

### DIFF
--- a/src/MarkdownSnippets/Reading/Exclusions/DefaultDirectoryExclusions.cs
+++ b/src/MarkdownSnippets/Reading/Exclusions/DefaultDirectoryExclusions.cs
@@ -5,13 +5,11 @@ public static class DefaultDirectoryExclusions
     public static bool ShouldExcludeDirectory(string path)
     {
         var suffix = Path.GetFileName(path).ToLowerInvariant();
-        return suffix is
-            ".git" or
-            ".vs" or
-            ".idea" or
-            "packages" or
-            "node_modules" or
-            "bin" or
-            "obj";
+        return suffix.StartsWith('.') ||
+               suffix is
+                   "packages" or
+                   "node_modules" or
+                   "bin" or
+                   "obj";
     }
 }

--- a/src/Tests/DirectoryMarkdownProcessorTests.cs
+++ b/src/Tests/DirectoryMarkdownProcessorTests.cs
@@ -502,6 +502,16 @@ public class DirectoryMarkdownProcessorTests
         processor.Run();
     }
 
+    [Theory]
+    [InlineData(".git")]
+    [InlineData(".vs")]
+    [InlineData(".idea")]
+    [InlineData(".vscode")]
+    [InlineData(".angular")]
+    [InlineData(".somearbitrarypaththatstartsiwthafullstop")]
+    public void AllPathsStartingWithAFullStopAreExcludedByDefault(string path) =>
+        Assert.True(DefaultDirectoryExclusions.ShouldExcludeDirectory(path));
+
     static Snippet SnippetBuild(string key, string? path = null) =>
         Snippet.Build(
             language: "cs",


### PR DESCRIPTION
This changes makes the behaviour consistent with the assertion here: https://github.com/SimonCropp/MarkdownSnippets/blob/main/docs/exclusion.md#ignored-paths

Specifically: `All directories and files starting with a period .`