### PR TITLE
Add DevOps formatting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,10 +266,11 @@ public enum LinkFormat
     Tfs,
     Bitbucket,
     GitLab,
+    DevOps,
     None
 }
 ```
-<sup><a href='/src/MarkdownSnippets/Processing/LinkFormat.cs#L1-L10' title='Snippet source file'>snippet source</a> | <a href='#snippet-LinkFormat.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/MarkdownSnippets/Processing/LinkFormat.cs#L1-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-LinkFormat.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Link format `None` will omit the source link but still keep the snippet anchor.
@@ -324,8 +325,13 @@ if (linkFormat == LinkFormat.GitLab)
     Polyfill.Append(builder, $"{path}#L{snippet.StartLine}-{snippet.EndLine}");
     return;
 }
+
+if (linkFormat == LinkFormat.DevOps)
+{
+    Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1");
+}
 ```
-<sup><a href='/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs#L96-L120' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildLink' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs#L96-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildLink' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.md
+++ b/readme.md
@@ -328,7 +328,7 @@ if (linkFormat == LinkFormat.GitLab)
 
 if (linkFormat == LinkFormat.DevOps)
 {
-    Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1");
+    Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1&lineEndColumn=999");
 }
 ```
 <sup><a href='/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs#L96-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildLink' title='Start of snippet'>anchor</a></sup>

--- a/src/MarkdownSnippets/Processing/LinkFormat.cs
+++ b/src/MarkdownSnippets/Processing/LinkFormat.cs
@@ -6,5 +6,6 @@ public enum LinkFormat
     Tfs,
     Bitbucket,
     GitLab,
+    DevOps,
     None
 }

--- a/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
@@ -120,7 +120,7 @@ public class SnippetMarkdownHandling
 
         if (linkFormat == LinkFormat.DevOps)
         {
-            Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1");
+            Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1&lineEndColumn=999");
         }
 
         #endregion

--- a/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
@@ -117,6 +117,12 @@ public class SnippetMarkdownHandling
             Polyfill.Append(builder, $"{path}#L{snippet.StartLine}-{snippet.EndLine}");
             return;
         }
+
+        if (linkFormat == LinkFormat.DevOps)
+        {
+            Polyfill.Append(builder, $"?path={path}&line={snippet.StartLine}&lineEnd={snippet.EndLine}&lineStartColumn=1");
+        }
+
         #endregion
 
         throw new($"Unknown LinkFormat: {linkFormat}");


### PR DESCRIPTION
This allows for correct navigation behaviour of snippet source links accessed from within markdown files that are part of an Azure DevOps repo being viewed in the browser.

It also adds code highlighting in this context, although it's worth noting this is currently stymied by inconsistent behaviour within DevOps: [Insert link to DevOps issue when it is made public]

It's possible that the current implementation of the Tfs link formatting option is incorrect, and should be replaced by the implementation of the proposed DevOps option. I'm not familiar with with previous versions of TFS to make that assumption though :)