### PR TITLE
Implemented a #L10-20 syntax for files, and #M-MethodName syntax for CSharp methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,32 @@ Will render:
 	<sup><a href='#snippet-license.txt' title='Start of snippet'>anchor</a></sup>
 	<!-- endSnippet -->
 
+### Including a partial file
+
+If no snippet is found matching the defined name. The target directory will be searched for a file matching that name. 
+Using a syntax of #L10-20 you can only include lines 10 to 20 from that file. For example:
+
+	<!-- snippet: license.txt#L1-3 -->
+	<a id='snippet-license.txt#L1-3'></a>
+	```txt
+	The MIT License (MIT)
+	...
+	```
+	<sup><a href='#snippet-license.txt' title='Start of snippet'>anchor</a></sup>
+	<!-- endSnippet -->
+
+### Including a C# Method
+
+If no snippet is found matching the defined name. The target directory will be searched for a file matching that name. 
+Using a syntax of #M-MethodName you can reference a specific method. For example:
+
+	<!-- snippet: src\ConfigReader\LogBuilder.cs#M-GetHeader -->
+	<a id='src\ConfigReader\LogBuilder.cs#M-GetHeader'></a>
+	```cs
+	...
+	```
+	<sup><a href='#src\ConfigReader\LogBuilder.cs' title='Start of snippet'>anchor</a></sup>
+	<!-- endSnippet -->
 
 ### LinkFormat
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -223,6 +223,32 @@ Will render:
 	<sup><a href='#snippet-license.txt' title='Start of snippet'>anchor</a></sup>
 	<!-- endSnippet -->
 
+### Including a partial file
+
+If no snippet is found matching the defined name. The target directory will be searched for a file matching that name. 
+Using a syntax of #L10-20 you can only include lines 10 to 20 from that file. For example:
+
+	<!-- snippet: license.txt#L1-3 -->
+	<a id='snippet-license.txt#L1-3'></a>
+	```txt
+	The MIT License (MIT)
+	...
+	```
+	<sup><a href='#snippet-license.txt' title='Start of snippet'>anchor</a></sup>
+	<!-- endSnippet -->
+
+### Including a C# Method
+
+If no snippet is found matching the defined name. The target directory will be searched for a file matching that name. 
+Using a syntax of #M-MethodName you can reference a specific method. For example:
+
+	<!-- snippet: src\ConfigReader\LogBuilder.cs#M-GetHeader -->
+	<a id='src\ConfigReader\LogBuilder.cs#M-GetHeader'></a>
+	```cs
+	...
+	```
+	<sup><a href='#src\ConfigReader\LogBuilder.cs' title='Start of snippet'>anchor</a></sup>
+	<!-- endSnippet -->
 
 ### LinkFormat
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Argon" Version="0.26.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.12.6" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Polyfill" Version="7.12.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.147" />

--- a/src/MarkdownSnippets/GlobalUsings.cs
+++ b/src/MarkdownSnippets/GlobalUsings.cs
@@ -1,5 +1,10 @@
-﻿global using System.Diagnostics.CodeAnalysis;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Net;
 global using System.Net.Http;
 global using System.Text.RegularExpressions;
 global using MarkdownSnippets;
+
+global using System.Text;
+global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.CSharp;
+global using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/MarkdownSnippets/MarkdownSnippets.csproj
+++ b/src/MarkdownSnippets/MarkdownSnippets.csproj
@@ -1,9 +1,9 @@
-
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net48;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(TargetFrameworkIdentifier)' == '.NETCOREAPP'" />


### PR DESCRIPTION
Hey there,

To make it easier to reference certain parts of code, I've added two new functions:

```
snippet: File.cs#L10-20
```

The purpose of this is to allow people to add a reference to a file, and indicate which line number range to include - instead of having to include everything.

```
snippet: File.cs#M-MethodName
```

The purpose of this is to allow people to add a reference to a file, and indicate method to include. This way you don't have to add regions to your codebase, and you can use specific methods as a reference.

I had some issues compiling and running parts of the code, but I managed to compile the MarkdownSnippets.Tool.exe and test the functionality on my own project. But I might have missed some things in usecases I haven't tried.

I've added the new logic to the `FileToSnippet` logic which creates an `Snippet` DTO, so the syntax is getting parsed and handled pretty high up in the program flow, without affecting lower level functions