### PR TITLE
Add support for expressive code in snippets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,50 @@ Windows Registry Editor Version 5.00
 <sup><a href='/src/context-menu.reg#L1-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-context-menu.reg' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Expressive Code / Snippet Metadata
+
+When defining snippets, you can add additional metadata at the source to the rendered snippet using the following syntax.
+
+```csharp
+// begin-snippet: HelloWorld(title=Program.cs {1})
+Console.WriteLine("Hello, World");
+// end-snippet
+```
+
+Note the text within the parenthesis; this is metadata we want to add to the rendered Markdown block immediately after the language declaration.
+The metadata is stripped and the key remains `HelloWorld`. The feature produces the following output at your target destination (will vary based on your configuration):
+
+````markdown
+<-- begin-snippet: HelloWorld -->
+```csharp title=Program.cs {1}
+Console.WriteLine("Hello, World");
+```
+<-- end-snippet -->
+````
+
+This syntax is known as [Expressive Code](https://expressive-code.com/) and is supported in documentation systems such
+as [Astro Starlight](https://github.com/withastro/starlight/) but can be installed in any Markdown-powered tool
+that supports [reHype](https://github.com/rehypejs/rehype).
+
+It is important to note, the metadata is not explicitly limited to Expressive code. Any text within the `()` will be rendered after
+the language block. This can be useful for adding additional information based on your specific rendering engine. For example, if
+you use a presentation tool such as [Sli.dev](https://sli.dev/), you can use this feature to apply [magic-move animations](https://sli.dev/features/shiki-magic-move).
+
+```csharp
+// begin-snippet: EncapsulateVariable({*|2})
+Console.WriteLine("Hello, World");
+// end-snippet
+```
+
+The above snippet will render as follows:
+
+````markdown
+<-- begin-snippet: EncapsulateVariable -->
+```csharp {*|2}
+Console.WriteLine("Hello, World");
+```
+<-- end-snippet -->
+````
 
 ## More Documentation
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Argon" Version="0.27.0" />
+    <PackageVersion Include="Argon" Version="0.28.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.13.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/src/MarkdownSnippets/Processing/MarkdownProcessor.cs
+++ b/src/MarkdownSnippets/Processing/MarkdownProcessor.cs
@@ -353,7 +353,8 @@ public class MarkdownProcessor
             value: text,
             key: key,
             language: Path.GetExtension(file)[1..],
-            path: path);
+            path: path,
+            expressiveCode: null);
     }
 
     (string text, int lineCount) ReadNonStartEndLines(string file)

--- a/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
@@ -15,7 +15,7 @@ public static class SimpleSnippetMarkdownHandling
 
     static void WriteSnippet(Action<string> appendLine, Snippet snippet)
     {
-        appendLine($"```{snippet.Language}");
+        appendLine($"```{snippet.Language} {snippet.ExpressiveCode}".TrimEnd());
         appendLine(snippet.Value);
         appendLine("```");
     }

--- a/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SimpleSnippetMarkdownHandling.cs
@@ -15,7 +15,11 @@ public static class SimpleSnippetMarkdownHandling
 
     static void WriteSnippet(Action<string> appendLine, Snippet snippet)
     {
-        appendLine($"```{snippet.Language} {snippet.ExpressiveCode}".TrimEnd());
+        var declaration =
+            string.IsNullOrWhiteSpace(snippet.ExpressiveCode)
+                ? snippet.Language
+                : $"{snippet.Language} {snippet.ExpressiveCode}";
+        appendLine($"```{declaration}");
         appendLine(snippet.Value);
         appendLine("```");
     }

--- a/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
@@ -86,7 +86,7 @@ public class SnippetMarkdownHandling
 
     static void WriteSnippetValueAndLanguage(Action<string> appendLine, Snippet snippet)
     {
-        appendLine($"```{snippet.Language}");
+        appendLine($"```{snippet.Language} {snippet.ExpressiveCode}".TrimEnd());
         appendLine(snippet.Value);
         appendLine("```");
     }

--- a/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
+++ b/src/MarkdownSnippets/Processing/SnippetMarkdownHandling.cs
@@ -86,7 +86,11 @@ public class SnippetMarkdownHandling
 
     static void WriteSnippetValueAndLanguage(Action<string> appendLine, Snippet snippet)
     {
-        appendLine($"```{snippet.Language} {snippet.ExpressiveCode}".TrimEnd());
+        var declaration =
+            string.IsNullOrWhiteSpace(snippet.ExpressiveCode)
+                ? snippet.Language
+                : $"{snippet.Language} {snippet.ExpressiveCode}";
+        appendLine($"```{declaration}");
         appendLine(snippet.Value);
         appendLine("```");
     }

--- a/src/MarkdownSnippets/Reading/ExpressiveCode.cs
+++ b/src/MarkdownSnippets/Reading/ExpressiveCode.cs
@@ -1,0 +1,17 @@
+internal partial class ExpressiveCode
+{
+    public ExpressiveCode() =>
+#if NET8_0_OR_GREATER
+        Pattern = KeyPatternRegex();
+#else
+        Pattern = KeyPatternRegex;
+#endif
+    public static ExpressiveCode Instance { get; } = new();
+    public Regex Pattern { get; }
+#if NET8_0_OR_GREATER
+    [GeneratedRegex(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?")]
+    protected partial Regex KeyPatternRegex();
+#else
+    protected static readonly Regex KeyPatternRegex = new(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?");
+#endif
+}

--- a/src/MarkdownSnippets/Reading/ExpressiveCode.cs
+++ b/src/MarkdownSnippets/Reading/ExpressiveCode.cs
@@ -1,5 +1,11 @@
 internal partial class ExpressiveCode
 {
+#if NET8_0_OR_GREATER
+    [GeneratedRegex(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?")]
+    protected partial Regex KeyPatternRegex();
+#else
+    protected static readonly Regex KeyPatternRegex = new(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?");
+#endif
     public ExpressiveCode() =>
 #if NET8_0_OR_GREATER
         Pattern = KeyPatternRegex();
@@ -8,10 +14,4 @@ internal partial class ExpressiveCode
 #endif
     public static ExpressiveCode Instance { get; } = new();
     public Regex Pattern { get; }
-#if NET8_0_OR_GREATER
-    [GeneratedRegex(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?")]
-    protected partial Regex KeyPatternRegex();
-#else
-    protected static readonly Regex KeyPatternRegex = new(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?");
-#endif
 }

--- a/src/MarkdownSnippets/Reading/FileSnippetExtractor.cs
+++ b/src/MarkdownSnippets/Reading/FileSnippetExtractor.cs
@@ -43,7 +43,7 @@ public static class FileSnippetExtractor
             throw new SnippetException($"Unable to get UrlAsSnippet: {url}");
         }
 
-        var snippet = Snippet.Build(1, content!.LineCount(), content!, key, GetLanguageFromPath(url), url);
+        var snippet = Snippet.Build(1, content!.LineCount(), content!, key, GetLanguageFromPath(url), url, null);
         snippets.Add(snippet);
 
         using var reader = new StringReader(content!);
@@ -71,7 +71,7 @@ public static class FileSnippetExtractor
     {
         Guard.FileExists(filePath, nameof(filePath));
         var text = File.ReadAllText(filePath);
-        var snippet = Snippet.Build(1, text.LineCount(), text, key, GetLanguageFromPath(filePath), filePath);
+        var snippet = Snippet.Build(1, text.LineCount(), text, key, GetLanguageFromPath(filePath), filePath, null);
         snippets.Add(snippet);
     }
 
@@ -153,9 +153,9 @@ public static class FileSnippetExtractor
 
             var trimmedLine = line.Trim();
 
-            if (StartEndTester.IsStart(trimmedLine, path, out var key, out var endFunc))
+            if (StartEndTester.IsStart(trimmedLine, path, out var key, out var endFunc, out var expressive))
             {
-                loopStack.Push(endFunc, key, index, maxWidth, newLine);
+                loopStack.Push(endFunc, key, index, maxWidth, newLine, expressive);
                 continue;
             }
 
@@ -207,7 +207,8 @@ public static class FileSnippetExtractor
             key: loopState.Key,
             value: value,
             path: path,
-            language: language.ToLowerInvariant()
+            language: language.ToLowerInvariant(),
+            expressiveCode: loopState.ExpressiveCode
         );
     }
 }

--- a/src/MarkdownSnippets/Reading/LoopStack.cs
+++ b/src/MarkdownSnippets/Reading/LoopStack.cs
@@ -15,9 +15,9 @@ class LoopStack
 
     public void Pop() => stack.Pop();
 
-    public void Push(EndFunc endFunc, string key, int startLine, int maxWidth, string newLine)
+    public void Push(EndFunc endFunc, string key, int startLine, int maxWidth, string newLine, string? block)
     {
-        var state = new LoopState(key, endFunc, startLine, maxWidth, newLine);
+        var state = new LoopState(key, endFunc, startLine, maxWidth, newLine, block);
         stack.Push(state);
     }
 

--- a/src/MarkdownSnippets/Reading/LoopState.cs
+++ b/src/MarkdownSnippets/Reading/LoopState.cs
@@ -1,5 +1,5 @@
 ﻿[DebuggerDisplay("Key={Key}")]
-class LoopState(string key, EndFunc endFunc, int startLine, int maxWidth, string newLine)
+class LoopState(string key, EndFunc endFunc, int startLine, int maxWidth, string newLine, string? expressiveCode = null)
 {
     public string GetLines()
     {
@@ -85,4 +85,5 @@ class LoopState(string key, EndFunc endFunc, int startLine, int maxWidth, string
     public EndFunc EndFunc { get; } = endFunc;
     public int StartLine { get; } = startLine;
     int newlineCount;
+    public string? ExpressiveCode { get; } = expressiveCode;
 }

--- a/src/MarkdownSnippets/Reading/Snippet.cs
+++ b/src/MarkdownSnippets/Reading/Snippet.cs
@@ -26,7 +26,7 @@ public class Snippet :
     /// <summary>
     /// Initialise a new instance of <see cref="Snippet"/>.
     /// </summary>
-    public static Snippet Build(int startLine, int endLine, string value, string key, string language, string? path)
+    public static Snippet Build(int startLine, int endLine, string value, string key, string language, string? path, string? expressiveCode)
     {
         Guard.AgainstNullAndEmpty(key, nameof(key));
         Guard.AgainstEmpty(path, nameof(path));
@@ -46,6 +46,7 @@ public class Snippet :
             Key = key,
             language = language,
             Path = path,
+            ExpressiveCode = expressiveCode,
             Error = ""
         };
     }
@@ -60,6 +61,12 @@ public class Snippet :
     public string Key { get; private init; } = null!;
 
     /// <summary>
+    /// An associated expressive code block with the snippet
+    /// See https://expressive-code.com/
+    /// </summary>
+    public string? ExpressiveCode { get; private init; }
+
+    /// <summary>
     /// The language of the snippet, extracted from the file extension of the input file.
     /// </summary>
     public string Language
@@ -70,6 +77,7 @@ public class Snippet :
             return language!;
         }
     }
+
     string? language;
 
     /// <summary>
@@ -98,6 +106,7 @@ public class Snippet :
             {
                 return null;
             }
+
             return $"{Path}({StartLine}-{EndLine})";
         }
     }

--- a/src/MarkdownSnippets/Reading/StartEndTester.cs
+++ b/src/MarkdownSnippets/Reading/StartEndTester.cs
@@ -2,8 +2,6 @@
 
 static partial class StartEndTester
 {
-    static readonly Regex keyPatternRegex = new(@"([a-zA-Z0-9\-_]+)(?:\((.*?)\))?");
-
     internal static bool IsStartOrEnd(string trimmedLine) =>
         IsBeginSnippet(trimmedLine) ||
         IsEndSnippet(trimmedLine) ||
@@ -103,7 +101,7 @@ static partial class StartEndTester
         var substring = line
             .TrimBackCommentChars(startIndex);
 
-        var match = keyPatternRegex.Match(substring);
+        var match = ExpressiveCode.Instance.Pattern.Match(substring);
 
         if (match.Length == 0)
         {

--- a/src/Tests/DirectoryMarkdownProcessorTests.cs
+++ b/src/Tests/DirectoryMarkdownProcessorTests.cs
@@ -507,5 +507,6 @@ public class DirectoryMarkdownProcessorTests
             endLine: 2,
             value: "the code from " + key,
             key: key,
-            path: path);
+            path: path,
+            expressiveCode: null);
 }

--- a/src/Tests/MarkdownProcessor/MarkdownProcessorTests.cs
+++ b/src/Tests/MarkdownProcessor/MarkdownProcessorTests.cs
@@ -204,7 +204,8 @@ public class MarkdownProcessorTests
                            Snippet
                            """,
                     key: "theKey",
-                    path: "thePath")
+                    path: "thePath",
+                    expressiveCode: null),
             ]);
     }
 
@@ -236,7 +237,8 @@ public class MarkdownProcessorTests
                            Snippet
                            """,
                     key: "theKey",
-                    path: "thePath")
+                    path: "thePath",
+                    expressiveCode: null)
             ]);
     }
 
@@ -669,5 +671,6 @@ public class MarkdownProcessorTests
             endLine: 2,
             value: "Snippet",
             key: key,
-            path: "thePath");
+            path: "thePath",
+            expressiveCode: null);
 }

--- a/src/Tests/SimpleSnippetMarkdownHandlingTests.ExpressiveCode.verified.txt
+++ b/src/Tests/SimpleSnippetMarkdownHandlingTests.ExpressiveCode.verified.txt
@@ -1,0 +1,3 @@
+﻿```cs title="HelloWorld.cs" {1}
+Console.WriteLine("Hello World");
+```

--- a/src/Tests/SimpleSnippetMarkdownHandlingTests.cs
+++ b/src/Tests/SimpleSnippetMarkdownHandlingTests.cs
@@ -4,7 +4,20 @@
     public Task Append()
     {
         var builder = new StringBuilder();
-        var snippets = new List<Snippet> {Snippet.Build(1, 2, "theValue", "thekey", "thelanguage", "thePath")};
+        var snippets = new List<Snippet> {Snippet.Build(1, 2, "theValue", "thekey", "thelanguage", "thePath", null)};
+        using (var writer = new StringWriter(builder))
+        {
+            SimpleSnippetMarkdownHandling.Append("key1", snippets, writer.WriteLine);
+        }
+
+        return Verify(builder.ToString());
+    }
+
+    [Fact]
+    public Task ExpressiveCode()
+    {
+        var builder = new StringBuilder();
+        var snippets = new List<Snippet> {Snippet.Build(1, 2, """Console.WriteLine("Hello World");""", "thekey", "cs", "thePath", """title="HelloWorld.cs" {1}""")};
         using (var writer = new StringWriter(builder))
         {
             SimpleSnippetMarkdownHandling.Append("key1", snippets, writer.WriteLine);

--- a/src/Tests/SnippetExtensionsTests.cs
+++ b/src/Tests/SnippetExtensionsTests.cs
@@ -30,5 +30,6 @@
             endLine: 2,
             value: "Snippet",
             key: key,
-            path: path);
+            path: path,
+            expressiveCode: null);
 }

--- a/src/Tests/SnippetExtractor/SnippetExtractorTests.CanExtractWithExpressiveCode.verified.txt
+++ b/src/Tests/SnippetExtractor/SnippetExtractorTests.CanExtractWithExpressiveCode.verified.txt
@@ -1,0 +1,10 @@
+﻿[
+  {
+    Key: CodeKey,
+    Language: cs,
+    Value: Console.WriteLine("Hello World");,
+    Error: ,
+    FileLocation: path.cs(1-3),
+    IsInError: false
+  }
+]

--- a/src/Tests/SnippetExtractor/SnippetExtractorTests.cs
+++ b/src/Tests/SnippetExtractor/SnippetExtractorTests.cs
@@ -288,4 +288,16 @@ public class SnippetExtractorTests
         var snippets = FromText(input);
         return Verify(snippets);
     }
+
+    [Fact]
+    public Task CanExtractWithExpressiveCode()
+    {
+        var input = """
+                      <!--begin-snippet: CodeKey(title="Program.cs" {1-3})-->
+                      Console.WriteLine("Hello World");
+                      <!--end-snippet-->
+                    """;
+        var snippets = FromText(input);
+        return Verify(snippets);
+    }
 }

--- a/src/Tests/SnippetMarkdownHandlingTests.cs
+++ b/src/Tests/SnippetMarkdownHandlingTests.cs
@@ -71,5 +71,5 @@ public class SnippetMarkdownHandlingTests
     }
 
     static List<Snippet> Snippets() =>
-        [Snippet.Build(1, 2, "theValue", "thekey", "thelanguage", Environment.CurrentDirectory)];
+        [Snippet.Build(1, 2, "theValue", "thekey", "thelanguage", Environment.CurrentDirectory, expressiveCode: null)];
 }

--- a/src/Tests/StartEndTester_IsBeginSnippetTests.cs
+++ b/src/Tests/StartEndTester_IsBeginSnippetTests.cs
@@ -3,23 +3,23 @@
     [Fact]
     public void CanExtractFromXml()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: CodeKey -->", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: CodeKey -->", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
     }
 
     [Fact]
     public Task ShouldThrowForNoKey() =>
-        Throws(() => StartEndTester.IsBeginSnippet("<!-- begin-snippet: -->", "file", out _));
+        Throws(() => StartEndTester.IsBeginSnippet("<!-- begin-snippet: -->", "file", out _, out _));
 
     [Fact]
     public void ShouldNotThrowForNoKeyWithNoSpace() =>
-        StartEndTester.IsBeginSnippet("<!--begin-snippet:-->", "file", out _);
+        StartEndTester.IsBeginSnippet("<!--begin-snippet:-->", "file", out _, out _);
 
     [Fact]
     public void CanExtractFromXmlWithMissingSpaces()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!--begin-snippet: CodeKey-->", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!--begin-snippet: CodeKey-->", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
     }
@@ -27,7 +27,7 @@
     [Fact]
     public void CanExtractFromXmlWithExtraSpaces()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!--  begin-snippet:  CodeKey  -->", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!--  begin-snippet:  CodeKey  -->", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
     }
@@ -35,7 +35,7 @@
     [Fact]
     public void CanExtractWithNoTrailingCharacters()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: CodeKey", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: CodeKey", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
     }
@@ -43,7 +43,7 @@
     [Fact]
     public void CanExtractWithUnderScores()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: Code_Key -->", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: Code_Key -->", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("Code_Key", key);
     }
@@ -51,7 +51,7 @@
     [Fact]
     public void CanExtractWithDashes()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: Code-Key -->", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("<!-- begin-snippet: Code-Key -->", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("Code-Key", key);
     }
@@ -59,17 +59,17 @@
     [Fact]
     public Task ShouldThrowForKeyStartingWithSymbol() =>
         Throws(() =>
-            StartEndTester.IsBeginSnippet("<!-- begin-snippet: _key-->", "file", out _));
+            StartEndTester.IsBeginSnippet("<!-- begin-snippet: _key-->", "file", out _, out _));
 
     [Fact]
     public Task ShouldThrowForKeyEndingWithSymbol() =>
         Throws(() =>
-            StartEndTester.IsBeginSnippet("<!-- begin-snippet: key_ -->", "file", out _));
+            StartEndTester.IsBeginSnippet("<!-- begin-snippet: key_ -->", "file", out _, out _));
 
     [Fact]
     public void CanExtractWithDifferentEndComments()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("/* begin-snippet: CodeKey */", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("/* begin-snippet: CodeKey */", "file", out var key,out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
     }
@@ -77,8 +77,26 @@
     [Fact]
     public void CanExtractWithDifferentEndCommentsAndNoSpaces()
     {
-        var isBeginSnippet = StartEndTester.IsBeginSnippet("/*begin-snippet: CodeKey */", "file", out var key);
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("/*begin-snippet: CodeKey */", "file", out var key, out _);
         Assert.True(isBeginSnippet);
         Assert.Equal("CodeKey", key);
+    }
+
+    [Fact]
+    public void CanExtractWithExpressiveCodeWithHtmlSnippet()
+    {
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("""<!--begin-snippet: CodeKey(title="Program.cs" {1-3})-->""", "file", out var key, out var block);
+        Assert.True(isBeginSnippet);
+        Assert.Equal("CodeKey", key);
+        Assert.Equal("""title="Program.cs" {1-3}""", block);
+    }
+
+    [Fact]
+    public void CanExtractWithExpressiveCodeWithCsharpComment()
+    {
+        var isBeginSnippet = StartEndTester.IsBeginSnippet("""/*begin-snippet: CodeKey(title="Program.cs" {1-3})*/""", "file", out var key, out var expressive);
+        Assert.True(isBeginSnippet);
+        Assert.Equal("CodeKey", key);
+        Assert.Equal("""title="Program.cs" {1-3}""", expressive);
     }
 }


### PR DESCRIPTION
This update introduces the handling of expressive code metadata for code snippets, enabling enhanced representation and functionality. Changes include parsing, storing, and rendering expressive attributes in snippets and updates to tests and relevant components to validate the new feature. Additionally, a package dependency (Argon) is updated for compatibility.

Only works for comment snippets currently.

See https://expressive-code.com/ for more details. #714

TL;DR:

This...

```csharp
<!--begin-snippet: CodeKey(title="Program.cs" {1-3})-->
Console.WriteLine("Hello World");
<!--end-snippet-->
```

Get converted into...

````markdown
```csharp title="Program.cs" {1-3}
Console.WriteLine("Hello World");
```
````