### PR TITLE
fix IncludeProcessor.AddInclude On2 list inserts

### DIFF
--- a/src/MarkdownSnippets/Processing/IncludeProcessor.cs
+++ b/src/MarkdownSnippets/Processing/IncludeProcessor.cs
@@ -129,13 +129,11 @@ class IncludeProcessor
     {
         used.Add(include);
         var linesToInject = BuildIncludes(line, include, writePath).ToList();
-        var first = linesToInject.First();
-        lines[index] = first;
+        lines[index] = linesToInject[0];
 
-        for (var includeIndex = 1; includeIndex < linesToInject.Count; includeIndex++)
+        if (linesToInject.Count > 1)
         {
-            var lineToInject = linesToInject[includeIndex];
-            lines.Insert(index + includeIndex, lineToInject);
+            lines.InsertRange(index + 1, linesToInject.GetRange(1, linesToInject.Count - 1));
         }
     }
 


### PR DESCRIPTION
IncludeProcessor.cs:131-139 — .ToList() then lines.Insert(index + i, ...) in a loop. Each Insert into the middle of a List<Line> is O(n) because it shifts all subsequent elements. For a large file with many includes, this is O(n²).
  Fix: collect all lines to inject, then do a single InsertRange.