### PR TITLE
Skip CLAUDE.md when scanning for files

### DIFF
--- a/src/MarkdownSnippets/Paths.cs
+++ b/src/MarkdownSnippets/Paths.cs
@@ -10,4 +10,7 @@ static class Paths
 
     public static bool IsIncludeMdFile(this string value) =>
         value.EndsWith(".include.md", StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsClaudeMdFile(this string value) =>
+        string.Equals(Path.GetFileName(value), "CLAUDE.md", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/MarkdownSnippets/Reading/FileFinder.cs
+++ b/src/MarkdownSnippets/Reading/FileFinder.cs
@@ -119,6 +119,11 @@
 
     static bool ShouldInclude(string file)
     {
+        if (file.IsClaudeMdFile())
+        {
+            return false;
+        }
+
         var extension = FileSnippetExtractor.GetLanguageFromPath(file);
         if (extension == string.Empty)
         {

--- a/src/Tests/PathsTests.cs
+++ b/src/Tests/PathsTests.cs
@@ -29,4 +29,16 @@ public class PathsTests
     [InlineData("file.md", false)]
     public void IsIncludeMdFile(string value, bool expected) =>
         Assert.Equal(expected, value.IsIncludeMdFile());
+
+    [Theory]
+    [InlineData("CLAUDE.md", true)]
+    [InlineData("claude.md", true)]
+    [InlineData("Claude.Md", true)]
+    [InlineData("dir/CLAUDE.md", true)]
+    [InlineData("C:/repo/CLAUDE.md", true)]
+    [InlineData("claudez.md", false)]
+    [InlineData("CLAUDE.source.md", false)]
+    [InlineData("file.md", false)]
+    public void IsClaudeMdFile(string value, bool expected) =>
+        Assert.Equal(expected, value.IsClaudeMdFile());
 }


### PR DESCRIPTION
CLAUDE.md is a Claude Code agent instruction file, not user documentation. Previously it was added to allFiles (reachable via include resolution) and, under InPlaceOverwrite, rewritten by the processor. Now FileFinder.ShouldInclude filters it out so it's invisible to snippet, markdown, and include scanning.